### PR TITLE
Add a mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Advent of Code</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.25.0/themes/prism.min.css" integrity="sha512-tN7Ec6zAFaVSG3TpNAKtk4DOHNpSwKHxxrsiw4GHKESGPs5njn/0sMCUMl2svV4wo4BK/rCP7juYz+zx+l6oeQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />

--- a/index.html
+++ b/index.html
@@ -14,10 +14,10 @@
   <body>
     <div class="container-fluid" style="margin: 1em 0;">
       <div class="row">
-        <div class="col-3">
+        <div class="col-sm-3">
           <ul id="users" class="list-group"></ul>
         </div>
-        <div class="col-9">
+        <div class="col-sm-9">
           <ul class="nav nav-pills">
             <li class="nav-item">
               <a class="nav-link part">A</a>

--- a/scripts.js
+++ b/scripts.js
@@ -197,8 +197,8 @@ window.addEventListener("load", async () => {
   users.forEach((user, index) => {
     const el = render`
       <li class="list-group-item">
-        <span>${user.name}</span>
-        <span>${user.langName}</span>
+        <span class="user-name">${user.name}</span>
+        <span class="user-lang-name">${user.langName}</span>
       </li>
     `;
     el.addEventListener("click", () => {

--- a/styles.css
+++ b/styles.css
@@ -23,6 +23,26 @@
   justify-content: space-between;
 }
 
+/* X-Small devices (e.g. portrait phones) */
+@media (max-width: 576px) {
+  #users {
+    flex-direction: row;
+    overflow: scroll;
+  }
+
+  .nav {
+    margin-top: 0;
+  }
+
+  .user-name {
+    white-space: nowrap;
+  }
+
+  .user-lang-name {
+    display: none;
+  }
+}
+
 @media (prefers-color-scheme: dark) {
   body, .nav, .list-group-item {
     background-color: #2d2d2d;


### PR DESCRIPTION
This branch makes the grid layout responsive and uses a scrollable tab-style layout (instead of the sidebar-style layout) on small devices, such as mobile phones in portrait mode:

![Screen Shot 2022-12-05 at 23 07 39](https://user-images.githubusercontent.com/30873659/205752997-0b13adfc-6e30-4f3d-9d49-54debe3cd499.png)

Thoughts @melfkammholz?