### PR TITLE
Migrate to ES6 modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,11 @@
 A small website showcasing different solutions for the Advent of Code.
 
 [The live page can be found here.](https://melfkammholz.github.io/aoc-submissions/)
+
+## Local Development
+
+Since the page uses ES6 modules, you'll need a web server to test the page locally. If you have Python installed, you can e.g. run
+
+```sh
+python3 -m http.server
+```

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="./styles.css" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.25.0/prism.min.js" integrity="sha512-hpZ5pDCF2bRCweL5WoA0/N1elet1KYL5mx3LP555Eg/0ZguaHawxNvEjF6O3rufAChs16HVNhEc6blF/rZoowQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.25.0/plugins/autoloader/prism-autoloader.min.js" integrity="sha512-sv0slik/5O0JIPdLBCR2A3XDg/1U3WuDEheZfI/DI5n8Yqc3h5kjrnr46FGBNiUAJF7rE4LHKwQ/SoSLRKAxEA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <script src="./scripts.js"></script>
+    <script src="src/scripts.js" type="module"></script>
   </head>
   <body>
     <div class="container-fluid" style="margin: 1em 0;">

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,2 @@
+export const year = 2022;
+export const shortYear = year % 100;

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -1,0 +1,135 @@
+import { year } from './constants.js';
+import { loadUsers } from './users.js';
+
+window.addEventListener("load", async () => {
+  const users = await loadUsers();
+  const clamp = (min, max, val) => Math.min(max, Math.max(val, min));
+
+  const days = new Date(clamp(new Date(`${year}-12-01`).valueOf(), new Date(`${year}-12-25`).valueOf(), Date.now())).getDate();
+  const state = {
+    day: days - 1,
+    part: 0,
+    index: 0
+  };
+
+  async function loadSolution(user, day, part) {
+    const url = user.solutionUrl(day, part);
+    const preEl = document.createElement("pre");
+    const codeEl = document.createElement("code");
+    const lang = user.lang(day);
+    const encoding = ("encoding" in user ? user.encoding(day) : null) || "utf-8";
+    const decoder = new TextDecoder(encoding);
+    try {
+      const result = url ? await fetch(url) : null;
+      if (!(result?.ok ?? false)) {
+        throw new Error("No solution yet");
+      }
+      const buffer = await result.arrayBuffer();
+      const code = decoder.decode(buffer);
+      await Prism.plugins.autoloader.loadLanguages(
+        lang,
+        () => {
+          codeEl.innerHTML = Prism.highlight(code, Prism.languages[lang], user.lang);
+        }
+      );
+    } catch (err) {
+      codeEl.textContent = err.message;
+    }
+    preEl.appendChild(codeEl);
+    document.getElementById("preview").innerHTML = "";
+    document.getElementById("preview").appendChild(preEl);
+  }
+
+  function render(strings, ...values) {
+    const html = String.raw({ raw: strings }, ...values);
+    const el = document.createElement('div');
+    el.innerHTML = html;
+    return el.children[0];
+  }
+
+  function updateSolution() {
+    loadSolution(users[state.index], state.day, state.part);
+  }
+
+  function setActive(selector, index) {
+    const className = "active";
+    const activatedEl = document.querySelectorAll(selector)[index];
+    document.querySelectorAll(`${selector}.${className}`).forEach(el => el.classList.remove(className));
+    activatedEl.classList.add(className);
+  }
+
+  function selectUserByIndex(index) {
+    state.index = index;
+    setActive("#users .list-group-item", index);
+    updateSolution();
+  }
+
+  function selectDay(day) {
+    state.day = day;  
+    setActive(".nav .day", day);
+    updateSolution();
+  }
+
+  function selectPart(part) {
+    state.part = part;
+    setActive(".part", part);
+    updateSolution();
+  }
+
+  const mod = (x, m) => (x % m + m) % m;
+
+  window.addEventListener("keydown", (event) => {
+    if (event.key === "w" || event.key === "k" ) selectUserByIndex(mod(state.index - 1, users.length));
+    else if (event.key === "s" || event.key === "j") selectUserByIndex(mod(state.index + 1, users.length));
+    else if (event.key === "a" || event.key === "h") selectDay(mod(state.day - 1, days));
+    else if (event.key === "d" || event.key === "l") selectDay(mod(state.day + 1, days));
+    else if (event.key === "q") selectPart((state.part + 1) % 2);
+  });
+
+  users.forEach((user, index) => {
+    const el = render`
+      <li class="list-group-item">
+        <span class="user-name">${user.name}</span>
+        <span class="user-lang-name">${user.langName}</span>
+      </li>
+    `;
+    el.addEventListener("click", () => {
+      selectUserByIndex(index);
+    });
+    document.getElementById("users").appendChild(el);
+  });
+
+  Array.from(document.querySelectorAll(".part")).forEach((el, i) => {
+    el.addEventListener("click", () => {
+      selectPart(i);
+    });
+  });
+
+  [...Array(days)].forEach((_, i) => {
+    const el = document.createElement("li");
+    el.classList.add("nav-item");
+    const aEl = document.createElement("a");
+    aEl.classList.add("nav-link");
+    aEl.classList.add("day");
+    aEl.textContent = i + 1;
+    aEl.addEventListener("click", () => {
+      selectDay(i);
+    });
+    el.appendChild(aEl);
+    document.querySelector(".nav").appendChild(el);
+  });
+
+  document.querySelectorAll(".list-group-item")[state.index].classList.add("active");
+  document.querySelectorAll(".part")[state.part].classList.add("active");
+  document.querySelectorAll(".day")[state.day].classList.add("active");
+
+  loadSolution(users[state.index], state.day, state.part);
+});
+
+if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = "https://cdnjs.cloudflare.com/ajax/libs/prism/1.25.0/themes/prism-tomorrow.min.css";
+  document.querySelector("head").appendChild(link);
+}
+

--- a/src/users.js
+++ b/src/users.js
@@ -1,3 +1,5 @@
+import { year, shortYear } from './constants.js';
+
 /** Generates solution urls for GitHub. */
 function gitHubUrls({ user, repo, branch = "main", path }) {
   return {
@@ -11,10 +13,8 @@ function pad(n, zeros) {
   return `${n}`.padStart(zeros, "0");
 }
 
-window.addEventListener("load", async () => {
-  const year = 2022;
-  const shortYear = year % 100;
-
+/** Loads the list of users. */
+export async function loadUsers() {
   const fwcdPaths = await (await fetch(`https://raw.githubusercontent.com/fwcd/advent-of-code-${year}/main/paths.json`)).json();
   const estgPaths = await (await fetch(`https://raw.githubusercontent.com/estugon/advent-of-code-${year}/main/paths.json`)).json();
 
@@ -221,133 +221,5 @@ window.addEventListener("load", async () => {
   users.sort((a, b) => a.name.localeCompare(b.name));
   users.sort((a, b) => a.langName.localeCompare(b.langName));
 
-  const clamp = (min, max, val) => Math.min(max, Math.max(val, min));
-
-  const days = new Date(clamp(new Date(`${year}-12-01`).valueOf(), new Date(`${year}-12-25`).valueOf(), Date.now())).getDate();
-  const state = {
-    day: days - 1,
-    part: 0,
-    index: 0
-  };
-
-  async function loadSolution(user, day, part) {
-    const url = user.solutionUrl(day, part);
-    const preEl = document.createElement("pre");
-    const codeEl = document.createElement("code");
-    const lang = user.lang(day);
-    const encoding = ("encoding" in user ? user.encoding(day) : null) || "utf-8";
-    const decoder = new TextDecoder(encoding);
-    try {
-      const result = url ? await fetch(url) : null;
-      if (!(result?.ok ?? false)) {
-        throw new Error("No solution yet");
-      }
-      const buffer = await result.arrayBuffer();
-      const code = decoder.decode(buffer);
-      await Prism.plugins.autoloader.loadLanguages(
-        lang,
-        () => {
-          codeEl.innerHTML = Prism.highlight(code, Prism.languages[lang], user.lang);
-        }
-      );
-    } catch (err) {
-      codeEl.textContent = err.message;
-    }
-    preEl.appendChild(codeEl);
-    document.getElementById("preview").innerHTML = "";
-    document.getElementById("preview").appendChild(preEl);
-  }
-
-  function render(strings, ...values) {
-    const html = String.raw({ raw: strings }, ...values);
-    const el = document.createElement('div');
-    el.innerHTML = html;
-    return el.children[0];
-  }
-
-  function updateSolution() {
-    loadSolution(users[state.index], state.day, state.part);
-  }
-
-  function setActive(selector, index) {
-    const className = "active";
-    const activatedEl = document.querySelectorAll(selector)[index];
-    document.querySelectorAll(`${selector}.${className}`).forEach(el => el.classList.remove(className));
-    activatedEl.classList.add(className);
-  }
-
-  function selectUserByIndex(index) {
-    state.index = index;
-    setActive("#users .list-group-item", index);
-    updateSolution();
-  }
-
-  function selectDay(day) {
-    state.day = day;  
-    setActive(".nav .day", day);
-    updateSolution();
-  }
-
-  function selectPart(part) {
-    state.part = part;
-    setActive(".part", part);
-    updateSolution();
-  }
-
-  const mod = (x, m) => (x % m + m) % m;
-
-  window.addEventListener("keydown", (event) => {
-    if (event.key === "w" || event.key === "k" ) selectUserByIndex(mod(state.index - 1, users.length));
-    else if (event.key === "s" || event.key === "j") selectUserByIndex(mod(state.index + 1, users.length));
-    else if (event.key === "a" || event.key === "h") selectDay(mod(state.day - 1, days));
-    else if (event.key === "d" || event.key === "l") selectDay(mod(state.day + 1, days));
-    else if (event.key === "q") selectPart((state.part + 1) % 2);
-  });
-
-  users.forEach((user, index) => {
-    const el = render`
-      <li class="list-group-item">
-        <span class="user-name">${user.name}</span>
-        <span class="user-lang-name">${user.langName}</span>
-      </li>
-    `;
-    el.addEventListener("click", () => {
-      selectUserByIndex(index);
-    });
-    document.getElementById("users").appendChild(el);
-  });
-
-  Array.from(document.querySelectorAll(".part")).forEach((el, i) => {
-    el.addEventListener("click", () => {
-      selectPart(i);
-    });
-  });
-
-  [...Array(days)].forEach((_, i) => {
-    const el = document.createElement("li");
-    el.classList.add("nav-item");
-    const aEl = document.createElement("a");
-    aEl.classList.add("nav-link");
-    aEl.classList.add("day");
-    aEl.textContent = i + 1;
-    aEl.addEventListener("click", () => {
-      selectDay(i);
-    });
-    el.appendChild(aEl);
-    document.querySelector(".nav").appendChild(el);
-  });
-
-  document.querySelectorAll(".list-group-item")[state.index].classList.add("active");
-  document.querySelectorAll(".part")[state.part].classList.add("active");
-  document.querySelectorAll(".day")[state.day].classList.add("active");
-
-  updateSolution();
-});
-
-if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
-  const link = document.createElement("link");
-  link.rel = "stylesheet";
-  link.href = "https://cdnjs.cloudflare.com/ajax/libs/prism/1.25.0/themes/prism-tomorrow.min.css";
-  document.querySelector("head").appendChild(link);
+  return users;
 }
-

--- a/src/users.js
+++ b/src/users.js
@@ -1,17 +1,5 @@
 import { year, shortYear } from './constants.js';
-
-/** Generates solution urls for GitHub. */
-function gitHubUrls({ user, repo, branch = "main", path }) {
-  return {
-    solutionUrl: (day, part) => `https://raw.githubusercontent.com/${user}/${repo}/${branch}/${path(day, part)}`,
-    solutionWebUrl: (day, part) => `https://github.com/${user}/${repo}/blob/${branch}/${path(day, part)}`,
-  };
-}
-
-/** Pads the given number with the given number of zeros. */
-function pad(n, zeros) {
-  return `${n}`.padStart(zeros, "0");
-}
+import { gitHubUrls, pad } from './utils.js';
 
 /** Loads the list of users. */
 export async function loadUsers() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,12 @@
+/** Generates solution urls for GitHub. */
+export function gitHubUrls({ user, repo, branch = "main", path }) {
+  return {
+    solutionUrl: (day, part) => `https://raw.githubusercontent.com/${user}/${repo}/${branch}/${path(day, part)}`,
+    solutionWebUrl: (day, part) => `https://github.com/${user}/${repo}/blob/${branch}/${path(day, part)}`,
+  };
+}
+
+/** Pads the given number with the given number of zeros. */
+export function pad(n, zeros) {
+  return `${n}`.padStart(zeros, "0");
+}


### PR DESCRIPTION
Since we're building a vanilla website anyway, why not take the chance of trying out some cutting-edge features. This branch migrates the script to an [ES6 module](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules), which let us modularize the project quite easily without requiring a build step. ES modules are supported by all major browsers at this point.

Thoughts?