### PR TITLE
Fix: Adjust paths for H1ghBre4k3r

### DIFF
--- a/src/users.js
+++ b/src/users.js
@@ -150,7 +150,7 @@ export async function loadUsers() {
       ...gitHubUrls({
         user: "H1ghBre4k3r",
         repo: `aoc-${year}`,
-        path: day => `src/day_${pad(day + 1, 2).rs}`
+        path: day => `src/day_${pad(day + 1, 2)}.rs`
       })
     },
     {


### PR DESCRIPTION
Currently, the paths for H1ghBre4k3r are determined incorrectly. The evil part is a little typo:
```js
path: day => `src/day_${pad(day + 1, 2).rs}`
``` 
This leads to the result `src/day_undefined`, because (obviously) the result of `pad(day + 1, 2)` has no field `rs`. 

To adjust this, I moved the `.rs` "back into the string":

```diff
- path: day => `src/day_${pad(day + 1, 2).rs}`
+ path: day => `src/day_${pad(day + 1, 2)}.rs`
```