### PR TITLE
Add client-side routing by encoding state in query parameters

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -58,21 +58,39 @@ window.addEventListener("load", async () => {
     activatedEl.classList.add(className);
   }
 
+  function loadStateFromQueryParams() {
+    const params = new URLSearchParams(window.location.search);
+    for (const key in state) {
+      state[key] = params.get(key) ?? state[key];
+    }
+  }
+
+  function updateQueryParams() {
+    const params = new URLSearchParams(window.location.search);
+    for (const key in state) {
+      params.set(key, state[key]);
+    }
+    history.pushState(null, "", `${window.location.pathname}?${params}`);
+  }
+
   function selectUserByIndex(index) {
     state.index = index;
     setActive("#users .list-group-item", index);
+    updateQueryParams();
     updateSolution();
   }
 
   function selectDay(day) {
     state.day = day;  
     setActive(".nav .day", day);
+    updateQueryParams();
     updateSolution();
   }
 
   function selectPart(part) {
     state.part = part;
     setActive(".part", part);
+    updateQueryParams();
     updateSolution();
   }
 
@@ -118,6 +136,8 @@ window.addEventListener("load", async () => {
     el.appendChild(aEl);
     document.querySelector(".nav").appendChild(el);
   });
+
+  loadStateFromQueryParams();
 
   selectUserByIndex(state.index);
   selectPart(state.part);

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -61,7 +61,7 @@ window.addEventListener("load", async () => {
   function updateQueryParams() {
     const params = new URLSearchParams(window.location.search);
     for (const key in state) {
-      params.set(key, state[key]);
+      params.set(key, `${state[key]}`);
     }
     history.pushState(null, "", `${window.location.pathname}?${params}`);
   }
@@ -89,7 +89,7 @@ window.addEventListener("load", async () => {
     const params = new URLSearchParams(window.location.search);
     const loaded = {};
     for (const key in state) {
-      loaded[key] = params.get(key);
+      loaded[key] = parseInt(params.get(key));
     }
     updateState({ ...loaded, updateQuery: false });
   }


### PR DESCRIPTION
By encoding the state in the URL, users can now to link to specific combinations of user/day/part and also navigate with their browser's back/forward button. Additionally, reloading now also preserves the state.

https://user-images.githubusercontent.com/30873659/206876608-b1bd2ff2-1544-482f-b36c-1aaefcc1bc91.mov