### PR TITLE
Make language name dependent on day

### DIFF
--- a/2022/src/users.js
+++ b/2022/src/users.js
@@ -206,8 +206,5 @@ export async function loadUsers() {
     }
   ];
 
-  users.sort((a, b) => a.name.localeCompare(b.name));
-  users.sort((a, b) => a.langName.localeCompare(b.langName));
-
   return users;
 }

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -11,7 +11,7 @@ window.addEventListener("load", async () => {
     index: 0
   };
 
-  const users = await loadUsers(days);
+  const users = await loadUsers();
 
   async function loadSolution(user, day, part) {
     const url = user.solutionUrl(day, part);
@@ -78,10 +78,37 @@ window.addEventListener("load", async () => {
     history.pushState(null, "", `${window.location.pathname}?${params}`);
   }
 
+  function updateUsers() {
+    const usersEl = document.getElementById("users");
+    usersEl.innerHTML = "";
+
+    users.sort((a, b) => a.name.localeCompare(b.name));
+    users.sort((a, b) => a.langName(state.day).localeCompare(b.langName(state.day)));
+
+    users.forEach((user, index) => {
+      const el = render`
+        <li class="list-group-item">
+          <span class="user-name">${user.name}</span>
+          <span class="user-lang">
+            ${user.langAnnotation ? `<span class="user-lang-annotation">${user.langAnnotation}</span>` : ""}
+            <span class="user-lang-name">${user.langName(state.day)}</span>
+          </span>
+        </li>
+      `;
+      el.addEventListener("click", () => {
+        updateState({ index });
+      });
+      usersEl.appendChild(el);
+    });
+  }
+
   function updateState({ index = null, day = null, part = null, updateActive = false, updateQuery = true }) {
     state.index = index ?? state.index;
     state.day = day ?? state.day;
     state.part = part ?? state.part;
+    if (day !== null) {
+      updateUsers();
+    }
     if (index !== null || updateActive) {
       setActive("#users .list-group-item", state.index);
     }
@@ -128,22 +155,6 @@ window.addEventListener("load", async () => {
 
   window.addEventListener("popstate", () => {
     loadStateFromQueryParams();
-  });
-
-  users.forEach((user, index) => {
-    const el = render`
-      <li class="list-group-item">
-        <span class="user-name">${user.name}</span>
-        <span class="user-lang">
-          ${user.langAnnotation ? `<span class="user-lang-annotation">${user.langAnnotation}</span>` : ""}
-          <span>${user.langName}</span>
-        </span>
-      </li>
-    `;
-    el.addEventListener("click", () => {
-      updateState({ index });
-    });
-    document.getElementById("users").appendChild(el);
   });
 
   Array.from(document.querySelectorAll(".part")).forEach((el, i) => {

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -80,7 +80,7 @@ window.addEventListener("load", async () => {
   }
 
   function updateQueryParams() {
-    const params = new URLSearchParams(window.location.search);
+    const params = new URLSearchParams();
     for (const key in state) {
       params.set(key, `${state[key]}`);
     }

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -2,9 +2,10 @@ import { year } from './constants.js';
 import { loadUsers } from './users.js';
 
 window.addEventListener("load", async () => {
-  const users = await loadUsers();
-
+  const mod = (x, m) => (x % m + m) % m;
   const clamp = (min, max, val) => Math.min(max, Math.max(val, min));
+
+  const users = await loadUsers();
 
   const days = new Date(clamp(new Date(`${year}-12-01`).valueOf(), new Date(`${year}-12-25`).valueOf(), Date.now() - 6 * 60 * 60 * 1000)).getDate();
   const state = {
@@ -148,8 +149,6 @@ window.addEventListener("load", async () => {
     }
     updateState({ ...loaded, updateActive: true, updateQuery: false });
   }
-
-  const mod = (x, m) => (x % m + m) % m;
 
   function userNameWithOffset(userName, offset) {
     return users[mod(userIndex(userName) + offset, users.length)].name;

--- a/src/users.js
+++ b/src/users.js
@@ -197,5 +197,9 @@ export async function loadUsers() {
     },
   ];
 
+  if (new Set(users.map(u => u.name)).size != users.length) {
+    throw new Error("Users must have unique names!")
+  }
+
   return users;
 }

--- a/src/users.js
+++ b/src/users.js
@@ -2,7 +2,7 @@ import { year, shortYear } from './constants.js';
 import { gitHubUrls, pad } from './utils.js';
 
 /** Loads the list of users. */
-export async function loadUsers(days) {
+export async function loadUsers() {
   // TODO handle error if necessary?
   const fwcdPaths = await (await fetch(`https://raw.githubusercontent.com/fwcd/advent-of-code-${year}/main/paths.json`)).json().catch(() => ({}));
   const estgPaths = await (await fetch(`https://raw.githubusercontent.com/estugon/advent-of-code-${year}/main/paths.json`)).json().catch(() => ({}));
@@ -11,7 +11,7 @@ export async function loadUsers(days) {
     {
       name: "Alexander P",
       lang: _ => "clike",
-      langName: "C++",
+      langName: _ => "C++",
       ...gitHubUrls({
         user: "Zeldacrafter",
         repo: "CompProg-Solutions",
@@ -22,7 +22,7 @@ export async function loadUsers(days) {
     {
       name: "I3J03RN",
       lang: _ => "clike",
-      langName: "C++",
+      langName: _ => "C++",
       ...gitHubUrls({
         user: "I3J03RN",
         repo: "ProgrammingChallenges",
@@ -33,7 +33,7 @@ export async function loadUsers(days) {
     {
       name: "Melf",
       lang: _ => "lua",
-      langName: "Lua",
+      langName: _ => "Lua",
       ...gitHubUrls({
         user: "melfkammholz",
         repo: `aoc${shortYear}`,
@@ -44,7 +44,7 @@ export async function loadUsers(days) {
       name: "fwcd",
       lang: day => fwcdPaths[day]?.lang?.codemirror,
       langAnnotation: "Today: ",
-      langName: fwcdPaths[days - 1]?.lang?.name ?? "Unknown",
+      langName: day => fwcdPaths[day]?.lang?.name ?? "Unknown",
       encoding: day => fwcdPaths[day]?.encoding,
       ...gitHubUrls({
         user: "fwcd",
@@ -55,7 +55,7 @@ export async function loadUsers(days) {
     {
       name: "xtay2",
       lang: _ => "java",
-      langName: "Java",
+      langName: _ => "Java",
       ...gitHubUrls({
         user: "xtay2",
         repo: "AdventOfCode",
@@ -65,7 +65,7 @@ export async function loadUsers(days) {
     {
       name: "Yorik Hansen",
       lang: _ => "python",
-      langName: "Python",
+      langName: _ => "Python",
       ...gitHubUrls({
         user: "YorikHansen",
         repo: "AdventOfCode",
@@ -75,7 +75,7 @@ export async function loadUsers(days) {
     {
       name: "Skgland",
       lang: _ => "rust",
-      langName: "Rust",
+      langName: _ => "Rust",
       ...gitHubUrls({
         user: "Skgland",
         repo: "Advent-of-Code",
@@ -85,7 +85,7 @@ export async function loadUsers(days) {
     {
       name: "Estugon",
       lang: day => estgPaths[day]?.lang,
-      langName: "Mixed",
+      langName: _ => "Mixed",
       ...gitHubUrls({
         user: "Estugon",
         repo: `advent-of-code-${year}`,
@@ -95,7 +95,7 @@ export async function loadUsers(days) {
     {
       name: "Dormanil",
       lang: _ => "fsharp",
-      langName: "F#",
+      langName: _ => "F#",
       ...gitHubUrls({
         user: "Dormanil",
         repo: "Advent-of-Code",
@@ -106,7 +106,7 @@ export async function loadUsers(days) {
     {
       name: "b3z",
       lang: _ => "python",
-      langName: "Python",
+      langName: _ => "Python",
       ...gitHubUrls({
         user: "b3z",
         repo: "aoc",
@@ -117,7 +117,7 @@ export async function loadUsers(days) {
     {
       name: "Dobiko",
       lang: _ => "clike",
-      langName: "C#",
+      langName: _ => "C#",
       ...gitHubUrls({
         user: "jnccd",
         repo: `advent-of-code-${year}`,
@@ -127,7 +127,7 @@ export async function loadUsers(days) {
     {
       name: "H1tchhiker",
       lang: _ => "elixir",
-      langName: "Elixir",
+      langName: _ => "Elixir",
       ...gitHubUrls({
         user: "n00on",
         repo: "AdventOfCode",
@@ -137,7 +137,7 @@ export async function loadUsers(days) {
     {
       name: "H1ghBre4k3r",
       lang: _ => "rust",
-      langName: "Rust",
+      langName: _ => "Rust",
       ...gitHubUrls({
         user: "H1ghBre4k3r",
         repo: `aoc-${year}`,
@@ -147,7 +147,7 @@ export async function loadUsers(days) {
     {
       name: "Zihark",
       lang: _ => "haskell",
-      langName: "Haskell",
+      langName: _ => "Haskell",
       ...gitHubUrls({
         user: "Ziharrk",
         repo: `aoc${year}`,
@@ -157,7 +157,7 @@ export async function loadUsers(days) {
     {
       name: "sebfisch",
       lang: _ => "java",
-      langName: "Java",
+      langName: _ => "Java",
       ...gitHubUrls({
         user: "sebfisch",
         repo: "AdventOfCode",
@@ -168,7 +168,7 @@ export async function loadUsers(days) {
     {
       name: "hendrick404",
       lang: _ => "python",
-      langName: "Python",
+      langName: _ => "Python",
       ...gitHubUrls({
         user: "hendrick404",
         repo: `advent-of-code-${year}`,
@@ -178,7 +178,7 @@ export async function loadUsers(days) {
     {
       name: "maclement",
       lang: _ => "haskell",
-      langName: "Haskell",
+      langName: _ => "Haskell",
       ...gitHubUrls({
         user: "maclement",
         repo: `advent-of-code-${year}`,
@@ -188,7 +188,7 @@ export async function loadUsers(days) {
     {
       name: "Magi3r",
       lang: _ => "esolang",
-      langName: "DDP",
+      langName: _ => "DDP",
       ...gitHubUrls({
         user: "Magi3r",
         repo: `AoC-${year}`,
@@ -196,9 +196,6 @@ export async function loadUsers(days) {
       })
     },
   ];
-
-  users.sort((a, b) => a.name.localeCompare(b.name));
-  users.sort((a, b) => a.langName.localeCompare(b.langName));
 
   return users;
 }


### PR DESCRIPTION
This PR makes the language name day-dependent, so we can update (and reorder) the user list depending on the selected day. To achieve this, users are now identified by name rather than by index, which should also lead to slightly prettier/more robust URLs.